### PR TITLE
Resolve dependency errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -8,15 +8,23 @@
     "url": "git://github.com/dominictarr/bench-ssb.git"
   },
   "dependencies": {
+    "async-write": "^2.1.0",
+    "flumecodec": "0.0.1",
+    "flumedb": "^1.0.0",
+    "flumelog-offset": "^3.3.2",
+    "flumeview-reduce": "^1.3.14",
     "pull-cont": "^0.1.1",
     "pull-many": "^1.0.8",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.8",
     "rimraf": "^2.6.1",
-    "scuttlebot": "^11.3.0",
+    "scuttlebot": "^13.0.1",
     "secure-scuttlebutt": "^18.0.6",
     "ssb-client": "^4.5.7",
-    "ssb-keys": "^7.0.15"
+    "ssb-ebt": "^5.2.3",
+    "ssb-friends": "^3.1.3",
+    "ssb-keys": "^7.0.15",
+    "ssb-validate": "^3.0.11"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This adds dependencies that are missing from `package.json`, but usually found in Scuttlebot (or its dependency tree). I've also added an `.npmrc` because it looks like this repo is lockfile-free, and a basic `.gitignore`.

@arj03 Does this break anything by declaring the dependencies in `package.json`?